### PR TITLE
Get invites by email

### DIFF
--- a/db.go
+++ b/db.go
@@ -81,6 +81,9 @@ func GetUuidByEmail(email string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if uuid == nil {
+		return "", nil
+	}
 	return uuid.(string), nil
 }
 

--- a/server.go
+++ b/server.go
@@ -21,7 +21,7 @@ func (*server) IsEmailRegistered(_ context.Context, req *pb.IsEmailRegisteredReq
 	if err != nil {
 		return nil, err
 	} else {
-		return &pb.IsEmailRegisteredReply{IsRegistered: true, AccountUuid: uuid}, nil
+		return &pb.IsEmailRegisteredReply{IsRegistered: uuid != "", AccountUuid: uuid}, nil
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -25,25 +25,14 @@ func (*server) IsEmailRegistered(_ context.Context, req *pb.IsEmailRegisteredReq
 	}
 }
 
-func (s *server) GetInvites(_ context.Context, req *pb.GetInvitesRequest) (*pb.GetInvitesReply, error) {
-	accountUuid := req.AccountUuid
-	emails, err := GetAllEmailsByUuid(accountUuid)
+func (s *server) GetInvitesByEmail(_ context.Context, req *pb.GetInvitesByEmailRequest) (*pb.GetInvitesByEmailReply, error) {
+	email := req.Email
+	ret, err := GetInviteOrganizationsByEmail(email)
 	if err != nil {
 		return nil, err
 	}
 
-	var ret []string
-	for _, email := range emails {
-		invites, err := GetInviteOrganizationsByEmail(email)
-		if err != nil {
-			return nil, err
-		}
-		for _, invite := range invites {
-			ret = append(ret, invite)
-		}
-	}
-
-	return &pb.GetInvitesReply{
+	return &pb.GetInvitesByEmailReply{
 		OrganizationUuids: ret,
 	}, nil
 }


### PR DESCRIPTION
Changes service method used by /meet/ endpoint to use emails instead of uuids, allowing /meet/ to be used on emails without existing account.﻿

See #28